### PR TITLE
ADD Readme, Refactor EmbeddedRedis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # YouAndMe
 지역 사람들과 공감할 수 있는 지도 기반 블로깅 서비스
+![main](https://i.imgur.com/1vm3DyZ.png)
+
+/
+## ✨프로젝트 구조
+(2021.11.01 수정)
+![Imgur](https://i.imgur.com/rE56Ain.png)

--- a/src/main/java/com/yam/app/common/configuration/EmbeddedRedisConfiguration.java
+++ b/src/main/java/com/yam/app/common/configuration/EmbeddedRedisConfiguration.java
@@ -23,7 +23,6 @@ public class EmbeddedRedisConfiguration {
     public void redisServer() throws IOException {
         redisServer = RedisServer.builder()
             .port(redisPort)
-            .setting("maxheap 1gb")
             .build();
         redisServer.start();
     }

--- a/src/main/java/com/yam/app/common/configuration/EmbeddedRedisConfiguration.java
+++ b/src/main/java/com/yam/app/common/configuration/EmbeddedRedisConfiguration.java
@@ -21,7 +21,10 @@ public class EmbeddedRedisConfiguration {
 
     @PostConstruct
     public void redisServer() throws IOException {
-        redisServer = new RedisServer(redisPort);
+        redisServer = RedisServer.builder()
+            .port(redisPort)
+            .setting("maxheap 1gb")
+            .build();
         redisServer.start();
     }
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -14,7 +14,7 @@ spring:
   redis:
     host: localhost
     password:
-    port: 6379
+    port: 16379
 
 app:
   mail:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -14,7 +14,7 @@ spring:
   redis:
     host: localhost
     password:
-    port: 16379
+    port: 6379
 
 app:
   mail:


### PR DESCRIPTION
- 간단한 Readme 추가
- 특정 로컬 환경에서 테스트용 EmbeddedRedis 가 생성되지 않아 설정변경

`Error creating bean with name 'embeddedRedisConfiguration': Invocation of init method failed; nested exception is java.lang.RuntimeException: Can't start redis server. Check logs for details`
![image](https://user-images.githubusercontent.com/26001202/139650243-f872c1ff-eabf-4226-9a6c-44c1399def41.png)

로컬 환경의 메모리(RAM)에 따라, 기본으로 할당하는 [Redis 페이징 파일 크기가 너무커져서 디스크 부족으로 서버 실행이 불가능](https://blog.marcgravell.com/2014/03/windows-redis-64.html)하기 때문 이었음.

수정한 내용
  1. EmbeddedRedis maxheap size를 1gb로 고정
  2. 테스트 환경에서 포트번호가 충돌하지 않도록 포트번호 변경(6379->16379)